### PR TITLE
Fix missing default value for "formation" input

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ async function buildPushAndDeploy() {
   const dockerFilePath = core.getInput('dockerfile_path') || '.';
   const buildOptions = core.getInput('options') || '';
   const herokuAction = herokuActionSetUp(appName);
-  const formation = core.getInput('formation');
+  const formation = core.getInput('formation') || 'web';
   
   try {
     await exec(`docker build --file ${dockerFilePath}/Dockerfile ${buildOptions} --tag registry.heroku.com/${appName}/${formation} ${dockerFilePath}`);


### PR DESCRIPTION
The README indicates the default value of "formation" is "web", but that is not enforced by the code.

A missing "formation" value actually breaks the docker build on line 26, since the image tag will have a trailing forward slash, "/" that Docker doesn't like.

Closes #21