### PR TITLE
Fix the docs to reference latest version and make it a little easier to manage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Create Release
         id: creat_release
         uses: actions/create-release@v1
@@ -17,3 +19,11 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
+      - name: Extract version from tag
+        uses: damienaicheh/extract-version-from-tag-action@v1.0.0
+      - name: Move the latest major version tag
+        uses: rickstaa/action-create-tag@v1
+        with:
+          tag: v${{ env.MAJOR }}
+          message: "Move the latest major version"
+          force_push_tag: True

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Build, Push and Deploy to Heroku # set whatever name you want to this step
         id: heroku
-        uses: jctaveras/heroku-deploy@v1.0.0 # use the latest version of the action
+        uses: jctaveras/heroku-deploy@v2 # use the latest version of the action
         with:
           email: ${{ secrets.HEROKU_EMAIL }} # your heroku email
           api_key: ${{ secrets.HEROKU_API_KEY }} # your heroku api key


### PR DESCRIPTION
The key intent here was to make sure the latest version was actually the one displayed in the docs, as I had an issue with this recently caused by confusion when we thought 1.0.0 was the latest version but discovered the arguments etc. all shown on the Readme were out of sync with that version. I then wanted to make it a little more sustainable rather than bumping this doc for every minor/patch release, so have suggested extending the action to automatically move the major version tag (e.g. V2) whenever a minor/patch is released, [as per the suggestion in the docs](https://docs.github.com/en/actions/creating-actions/about-custom-actions#using-tags-for-release-management) so that future users can just ask for `v2` and consistently receive the most up to date version despite no change to the current release process.

Happy to limit this to just the doc change (but tweaked to point to a specific minor version) if you'd rather not add the other section